### PR TITLE
fix error with values

### DIFF
--- a/tests/Controller/MyControllerTest.php
+++ b/tests/Controller/MyControllerTest.php
@@ -37,21 +37,20 @@ class MyControllerTest extends WebTestCase
 
         $form = $crawler->filter('form')->form();
 
-        $paymentData = [];
-        $paymentData['invoice_form[client]'] = 123456;
-        $paymentData['invoice_form[transactionNumber]'] = "ABCD12346";
+        $values = $form->getPhpValues();
+
+        $values['invoice_form']['client'] = 123456;
+        $values['invoice_form']['transactionNumber'] = "ABCD12346";
 
         $i = 0;
         foreach ($invoices as $invoice) {
-            $paymentData["invoice_form[payments][$i][amount]"] = $invoice['amount'];
-            $paymentData["invoice_form[payments][$i][note]"] = $invoice['note'];
+            $values["invoice_form"]['payments'][$i]['amount'] = $invoice['amount'];
+            $values["invoice_form"]['payments'][$i]['note'] = $invoice['note'];
             $i++;
         }
 
-        $form->setValues($paymentData);
-
         // submit
-        $client = $client->submit($form);
+        $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
         // assert post was successful and redirects to the respectful route.
         $this->assertTrue($client->getResponse()->isRedirect('/'));


### PR DESCRIPTION
If you want to add or remove dynamic fields, you need to call ` $values = $form->getPhpValues();` and alter this array as you want.

`setValues()` and `submit()` will crash because they don't accept new or missing fields, that's the expected behaviour.

See https://github.com/symfony/symfony/issues/45150#issuecomment-1030874215